### PR TITLE
Add Flask web app to parse and filter XML data

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,54 @@
+import glob
+import json
+import os
+from flask import Flask, request, render_template
+import xmltodict
+
+app = Flask(__name__)
+
+CONFIG_PATH = os.environ.get("CONFIG_PATH", "config.json")
+if os.path.exists(CONFIG_PATH):
+    with open(CONFIG_PATH) as f:
+        config = json.load(f)
+else:
+    config = {}
+
+FILTERABLE_ATTRIBUTES = set(config.get("filterable_attributes", []))
+
+
+def load_records(directory="2024"):
+    records = []
+    for path in glob.glob(os.path.join(directory, "*.xml")):
+        with open(path, "r", encoding="utf-8") as f:
+            data = xmltodict.parse(f.read())
+            records.append((os.path.basename(path), data))
+    return records
+
+
+def flatten_dict(d, parent_key="", sep="."):
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+@app.route("/")
+def index():
+    raw_records = load_records()
+    filters = {k: v for k, v in request.args.items() if k in FILTERABLE_ATTRIBUTES}
+    processed = []
+    for _, record in raw_records:
+        flat = flatten_dict(record)
+        if all(str(flat.get(attr, "")).lower() == val.lower() for attr, val in filters.items()):
+            processed.append(flat)
+        elif not filters:
+            processed.append(flat)
+    return render_template("index.html", records=processed, filterable=FILTERABLE_ATTRIBUTES)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "filterable_attributes": [
+    "Return.ReturnHeader.PreparerFirmGrp.PreparerUSAddress.CityNm",
+    "Return.ReturnHeader.PreparerFirmGrp.PreparerUSAddress.StateAbbreviationCd",
+    "Return.ReturnHeader.PreparerFirmGrp.PreparerUSAddress.ZIPCd"
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+xmltodict

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Form 990 Viewer</title>
+  </head>
+  <body>
+    <h1>Form 990 Viewer</h1>
+    <form method="get">
+      {% for attr in filterable %}
+        <label>{{ attr }}:
+          <input type="text" name="{{ attr }}" value="{{ request.args.get(attr, '') }}">
+        </label><br>
+      {% endfor %}
+      <button type="submit">Filter</button>
+    </form>
+
+    {% for record in records %}
+      <h2>Record {{ loop.index }}</h2>
+      <table border="1">
+        {% for k, v in record.items() %}
+        <tr><th>{{ k }}</th><td>{{ v }}</td></tr>
+        {% endfor %}
+      </table>
+    {% endfor %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal Flask application that loads XML files and flattens their attributes
- allow configurable attribute-based filtering via `config.json`
- include HTML template for displaying records and simple requirements file

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c7392715bc832d817699a1d4259c31